### PR TITLE
fix: GitHub トークン検証のエラーハンドリングを改善

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@auth/drizzle-adapter": "^1.11.1",
     "@hookform/resolvers": "^5.2.2",
     "@neondatabase/serverless": "^1.0.2",
+    "@octokit/request-error": "^7.1.0",
     "@octokit/rest": "^22.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
+      '@octokit/request-error':
+        specifier: ^7.1.0
+        version: 7.1.0
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1


### PR DESCRIPTION
## Summary
- GitHub トークン検証時のcatchブロックでエラーの種類を判別し、適切なメッセージを返すように修正
- `@octokit/request-error` の `RequestError` を使用して、401/403/5xx/ネットワークエラーをそれぞれ区別
- レート制限(403 + x-ratelimit-remaining)とスコープ不足(403)を正しく判別

Closes #1

## Test plan
- [ ] 無効なトークンを入力して401エラーメッセージを確認
- [ ] `repo`スコープなしのトークンで403エラーメッセージを確認
- [ ] 有効なトークンで正常に接続できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)