### PR TITLE
feat: ダークモード対応

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
       <body className={`${notoSansJP.variable} font-sans antialiased`}>
         <Providers>
           {children}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -15,6 +15,8 @@ import {
   SidebarFooter,
 } from "@/components/ui/sidebar";
 import { signOut } from "next-auth/react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const mainNav = [
@@ -38,6 +40,7 @@ const settingsNav = [
 
 export function AppSidebar() {
   const pathname = usePathname();
+  const { theme, setTheme } = useTheme();
 
   return (
     <Sidebar>
@@ -128,7 +131,17 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter className="border-t p-4">
+      <SidebarFooter className="border-t p-4 space-y-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        >
+          <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="ml-1">テーマ切替</span>
+        </Button>
         <Button
           variant="ghost"
           size="sm"

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
 import type { ReactNode } from "react";
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- `next-themes` の `ThemeProvider` を `Providers` に追加し、ダークモードを有効化
- `<html>` タグに `suppressHydrationWarning` を追加
- サイドバーのフッターにテーマ切替ボタンを追加（Sun/Moon アイコン）

## Test plan
- [ ] サイドバーの「テーマ切替」ボタンでライト/ダークが切り替わることを確認
- [ ] ページリロード後もテーマが維持されることを確認
- [ ] OS設定がダークモードの場合、初回アクセス時にダークモードで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)